### PR TITLE
fix: Support defaults channel

### DIFF
--- a/src/packing_packages/pack/_core.py
+++ b/src/packing_packages/pack/_core.py
@@ -128,7 +128,7 @@ def packing_packages(
         if package.name == "python":
             env_python_version = package.version
 
-    # # conda listで取得したpythonのバージョンと、現在のpythonのバージョンが異なる場合は警告を出す
+    # conda listで取得したpythonのバージョンと、現在のpythonのバージョンが異なる場合は警告を出す
     if (
         tuple(map(int, env_python_version.split(".")[:2]))
         != sys.version_info[:2]
@@ -209,7 +209,11 @@ def packing_packages(
                     "--no-deps",
                     "--download-only",
                 ]
-                + (["-c", package.channel] if package.channel else [])
+                + (
+                    ["-c", package.channel]
+                    if package.channel
+                    else ["-c", "defaults"]
+                )
                 + (["--dry-run"] if dry_run else []),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
A bug that caused packages to be packed from other channels (high-priority channels set by users) instead of the default channel has been fixed.