### PR TITLE
fix(install): fix install order and script generation for priority packages

### DIFF
--- a/src/packing_packages/__init__.py
+++ b/src/packing_packages/__init__.py
@@ -16,7 +16,7 @@ dependencies into a specified directory.
 
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.1"
 __license__ = "MIT"
 __author__ = "yu9824"
 __copyright__ = "Copyright © 2025 yu9824"

--- a/src/packing_packages/install/_core.py
+++ b/src/packing_packages/install/_core.py
@@ -456,7 +456,7 @@ def generate_install_scripts(
                         "--no-build-isolation",
                     ]
                     + [
-                        f"^\r\n    {filepath_str}"
+                        f"^\\\r\\\n    {filepath_str}"
                         for filepath_str in tup_filepaths_pypi_str[
                             n_packages_each_iter * i : n_packages_each_iter
                             * (i + 1)

--- a/src/packing_packages/install/_core.py
+++ b/src/packing_packages/install/_core.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path, PureWindowsPath
 from typing import Optional, Union
 
@@ -155,6 +156,28 @@ def get_pypi_sorted_packages_path(
     return _sort_packages_by_priority(filepaths_pypi)
 
 
+def split_pypi_packages_by_priority(
+    packages_path: Sequence[Path],
+) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+    """Split PyPI package file paths by priority."""
+    list_prior_packages: list[Path] = []
+
+    for index_package in range(len(packages_path)):
+        package_path = packages_path[index_package]
+        package_path_stem = package_path.stem.replace("_", "-").lower()
+        package_name = package_path_stem.split("-")[0]
+
+        if package_name in PACKAGES_FOR_BUILD:
+            list_prior_packages.append(package_path)
+        else:
+            break
+
+    return (
+        tuple(list_prior_packages),
+        tuple(packages_path[index_package:]),
+    )
+
+
 def get_conda_sorted_packages_path(
     dirpath_packages: Union[os.PathLike, str] = ".",
 ) -> tuple[Path, ...]:
@@ -208,8 +231,8 @@ def install_packages(
 
     dirpath_packages = Path(dirpath_packages).resolve()
 
-    tup_filepaths_conda = _get_conda_packages_path(dirpath_packages)
-    tup_filepaths_pypi = _get_pypi_packages_path(dirpath_packages)
+    tup_filepaths_conda = get_conda_sorted_packages_path(dirpath_packages)
+    tup_filepaths_pypi = get_pypi_sorted_packages_path(dirpath_packages)
 
     list_filepaths_conda_failed: list[Path] = []
     # install conda packages
@@ -353,8 +376,8 @@ def generate_install_scripts(
         output_dir.mkdir(parents=True, exist_ok=True)
 
     # Find package files
-    tup_filepaths_conda = _get_conda_packages_path(dirpath_packages)
-    tup_filepaths_pypi = _get_pypi_packages_path(dirpath_packages)
+    tup_filepaths_conda = get_conda_sorted_packages_path(dirpath_packages)
+    tup_filepaths_pypi = get_pypi_sorted_packages_path(dirpath_packages)
 
     # Generate Windows batch file (.bat)
     bat_content = [
@@ -422,21 +445,47 @@ def generate_install_scripts(
     if tup_filepaths_pypi:
         bat_content.append("REM Install PyPI packages")
 
-        tup_filepaths_pypi_str = tuple(
+        tup_filepaths_pypi_prior, tup_filepaths_pypi_non_prior = (
+            split_pypi_packages_by_priority(tup_filepaths_pypi)
+        )
+        for filepath_pypi_prior in tup_filepaths_pypi_prior:
+            bat_content.append(
+                " ".join(
+                    [
+                        "call",
+                        "conda",
+                        "run",
+                        "-n",
+                        "%env_name%",
+                        "pip",
+                        "install",
+                        "--no-deps",
+                        "--no-build-isolation",
+                        str(
+                            PureWindowsPath(
+                                filepath_pypi_prior.relative_to(output_dir)
+                            )
+                        ),
+                    ]
+                )
+            )
+            bat_content.append("")
+
+        tup_filepaths_pypi_non_prior_str = tuple(
             [
                 "{}".format(
                     str(PureWindowsPath(filepath.relative_to(output_dir)))
                 )
-                for filepath in tup_filepaths_pypi
+                for filepath in tup_filepaths_pypi_non_prior
             ]
         )
-        n_str = sum(map(lambda x: len(x), tup_filepaths_pypi_str))
+        n_str = sum(map(lambda x: len(x), tup_filepaths_pypi_non_prior_str))
         _logger.debug(f"'{n_str}' letters.")
 
         n_split = (n_str // MAX_LETTER_LENGTH_BAT) + bool(
             n_str % MAX_LETTER_LENGTH_BAT
         )
-        n_packages = len(tup_filepaths_pypi_str)
+        n_packages = len(tup_filepaths_pypi_non_prior_str)
         n_packages_each_iter = n_packages // n_split + bool(
             n_packages % n_split
         )
@@ -456,8 +505,8 @@ def generate_install_scripts(
                         "--no-build-isolation",
                     ]
                     + [
-                        f"^\\\r\\\n    {filepath_str}"
-                        for filepath_str in tup_filepaths_pypi_str[
+                        f"^\r\n    {filepath_str}"
+                        for filepath_str in tup_filepaths_pypi_non_prior_str[
                             n_packages_each_iter * i : n_packages_each_iter
                             * (i + 1)
                         ]
@@ -512,6 +561,24 @@ def generate_install_scripts(
 
     if tup_filepaths_pypi:
         sh_content.append("# Install PyPI packages")
+        for filepath_pypi_prior in tup_filepaths_pypi_prior:
+            sh_content.append(
+                " ".join(
+                    [
+                        "conda",
+                        "run",
+                        "-n",
+                        "$env_name",
+                        "pip",
+                        "install",
+                        "--no-deps",
+                        "--no-build-isolation",
+                        filepath_pypi_prior.relative_to(output_dir).as_posix(),
+                    ]
+                )
+            )
+            sh_content.append("")
+
         sh_content.append(
             " ".join(
                 [
@@ -528,7 +595,7 @@ def generate_install_scripts(
                     '\\\n    "{}"'.format(
                         filepath.relative_to(output_dir).as_posix()
                     )
-                    for filepath in tup_filepaths_pypi
+                    for filepath in tup_filepaths_pypi_non_prior
                 ]
             )
         )

--- a/src/packing_packages/install/_core.py
+++ b/src/packing_packages/install/_core.py
@@ -178,6 +178,48 @@ def split_pypi_packages_by_priority(
     )
 
 
+def split_packages_path_for_bat(
+    packages_path: Sequence[Path], output_dir: Path
+) -> tuple[str, ...]:
+    """
+
+    Parameters
+    ----------
+    packages_path : Sequence[Path]
+        _description_
+    output_dir : Path
+        _description_
+
+    Returns
+    -------
+    tuple[str, ...]
+        _description_
+    """
+    tup_filepaths_conda_str = tuple(
+        [
+            "{}".format(str(PureWindowsPath(filepath.relative_to(output_dir))))
+            for filepath in packages_path
+        ]
+    )
+    n_str = sum(map(lambda x: len(x), tup_filepaths_conda_str))
+    _logger.debug(f"'{n_str}' letters.")
+
+    n_split = (n_str // MAX_LETTER_LENGTH_BAT) + bool(
+        n_str % MAX_LETTER_LENGTH_BAT
+    )
+    n_packages = len(tup_filepaths_conda_str)
+    n_packages_each_iter = n_packages // n_split + bool(n_packages % n_split)
+
+    return tuple(
+        " ^\r\n    ".join(
+            tup_filepaths_conda_str[
+                n_packages_each_iter * i : n_packages_each_iter * (i + 1)
+            ]
+        )
+        for i in range(n_split)
+    )
+
+
 def get_conda_sorted_packages_path(
     dirpath_packages: Union[os.PathLike, str] = ".",
 ) -> tuple[Path, ...]:
@@ -399,26 +441,9 @@ def generate_install_scripts(
     if tup_filepaths_conda:
         bat_content.append("REM Install conda packages")
 
-        tup_filepaths_conda_str = tuple(
-            [
-                "{}".format(
-                    str(PureWindowsPath(filepath.relative_to(output_dir)))
-                )
-                for filepath in tup_filepaths_conda
-            ]
-        )
-        n_str = sum(map(lambda x: len(x), tup_filepaths_conda_str))
-        _logger.debug(f"'{n_str}' letters.")
-
-        n_split = (n_str // MAX_LETTER_LENGTH_BAT) + bool(
-            n_str % MAX_LETTER_LENGTH_BAT
-        )
-        n_packages = len(tup_filepaths_conda_str)
-        n_packages_each_iter = n_packages // n_split + bool(
-            n_packages % n_split
-        )
-
-        for i in range(n_split):
+        for filepath_str in split_packages_path_for_bat(
+            tup_filepaths_conda, output_dir
+        ):
             bat_content.append(
                 " ".join(
                     [
@@ -430,13 +455,7 @@ def generate_install_scripts(
                         "%env_name%",
                         "--offline",
                         "--use-local",
-                    ]
-                    + [
-                        f"^\r\n    {filepath_str}"
-                        for filepath_str in tup_filepaths_conda_str[
-                            n_packages_each_iter * i : n_packages_each_iter
-                            * (i + 1)
-                        ]
+                        f"^\r\n    {filepath_str}",
                     ]
                 )
             )
@@ -471,26 +490,9 @@ def generate_install_scripts(
             )
             bat_content.append("")
 
-        tup_filepaths_pypi_non_prior_str = tuple(
-            [
-                "{}".format(
-                    str(PureWindowsPath(filepath.relative_to(output_dir)))
-                )
-                for filepath in tup_filepaths_pypi_non_prior
-            ]
-        )
-        n_str = sum(map(lambda x: len(x), tup_filepaths_pypi_non_prior_str))
-        _logger.debug(f"'{n_str}' letters.")
-
-        n_split = (n_str // MAX_LETTER_LENGTH_BAT) + bool(
-            n_str % MAX_LETTER_LENGTH_BAT
-        )
-        n_packages = len(tup_filepaths_pypi_non_prior_str)
-        n_packages_each_iter = n_packages // n_split + bool(
-            n_packages % n_split
-        )
-
-        for i in range(n_split):
+        for filepath_str in split_packages_path_for_bat(
+            tup_filepaths_pypi_non_prior, output_dir
+        ):
             bat_content.append(
                 " ".join(
                     [
@@ -503,13 +505,7 @@ def generate_install_scripts(
                         "install",
                         "--no-deps",
                         "--no-build-isolation",
-                    ]
-                    + [
-                        f"^\r\n    {filepath_str}"
-                        for filepath_str in tup_filepaths_pypi_non_prior_str[
-                            n_packages_each_iter * i : n_packages_each_iter
-                            * (i + 1)
-                        ]
+                        f"^\r\n    {filepath_str}",
                     ]
                 )
             )


### PR DESCRIPTION
## Summary

- Fix line-continuation escapes in generated `.bat` scripts (remove extra backslashes)
- Install build-essential PyPI packages (e.g. `setuptools`, `wheel`) individually with `--no-deps --no-build-isolation` before the bulk install to ensure they are available as build dependencies
- Refactor duplicated bat-path-splitting logic into a reusable `split_packages_path_for_bat()` helper
- Expose `get_conda_sorted_packages_path` / `get_pypi_sorted_packages_path` as public API and use them in `install_packages()` and `generate_install_scripts()`

## Test plan

- [ ] Run `generate_install_scripts()` and verify the generated `.bat` has correct line continuations (`^\r\n` not `^\\\r\\\n`)
- [ ] Verify priority packages (e.g. `setuptools`, `wheel`) appear as individual `pip install` commands before the bulk install in both `.bat` and `.sh` outputs
- [ ] Run `install_packages()` on a directory containing priority and non-priority PyPI packages and confirm installation succeeds in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)